### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ==================
 
 
-######作者:Chai Fei
-######E-mail:cforth@cfxyz.com
+###### 作者:Chai Fei
+###### E-mail:cforth@cfxyz.com
 ------------------
 
 2015-2016年股票关注，仅供参考。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
